### PR TITLE
Add prettydoc package to GitHub Actions workflow dependencies

### DIFF
--- a/.github/workflows/workflow_with_cmdstanr.yml
+++ b/.github/workflows/workflow_with_cmdstanr.yml
@@ -58,6 +58,7 @@ jobs:
             any::ggplot2
             any::tibble
             any::dplyr
+            any::prettydoc
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2

--- a/.github/workflows/workflow_with_cmdstanr.yml
+++ b/.github/workflows/workflow_with_cmdstanr.yml
@@ -40,6 +40,15 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Install R dependencies
+        shell: Rscript {0}
+        run: |
+          install.packages("SeuratObject")
+          if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager")
+          BiocManager::install()
+          if (!requireNamespace("devtools", quietly = TRUE)) install.packages("devtools")
+          devtools::install_deps(dependencies = TRUE)
+
       - name: Install CmdStan
         shell: Rscript {0}
         run: |

--- a/.github/workflows/workflow_with_cmdstanr.yml
+++ b/.github/workflows/workflow_with_cmdstanr.yml
@@ -45,7 +45,8 @@ jobs:
         run: |
           install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
-          cmdstanr::install_cmdstan()
+          cmdstanr::install_cmdstan(cores = 2)
+          cmdstanr::cmdstan_version()
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -45,6 +45,7 @@ Suggests:
     markdown,
     loo,
     prettydoc,
+    SeuratObject,
     tidyseurat,
     tidySingleCellExperiment,
     bayesplot,


### PR DESCRIPTION
This update includes the addition of the `prettydoc` package to the list of dependencies in the GitHub Actions workflow for R-CMD-check with CmdStan integration, enhancing documentation capabilities.