### PR TITLE
Update `prepare_replicate_data` to use `original_formula_composition`…

### DIFF
--- a/R/sccomp_replicate.R
+++ b/R/sccomp_replicate.R
@@ -147,6 +147,7 @@ prepare_replicate_data = function(X,
                                   .cell_group,
                                   .count,
                                   formula_composition,
+                                  original_formula_composition,
                                   formula_variability,
                                   new_data = NULL,
                                   original_count_data) {
@@ -283,7 +284,7 @@ prepare_replicate_data = function(X,
   if(create_intercept) warning("sccomp says: your estimated model is intercept free, while your desired replicated data do have an intercept term. The intercept estimate will be calculated averaging your first factor in your formula ~ 0 + <factor>. If you don't know the meaning of this warning, this is likely undesired, and please reconsider your formula for replicate_data()")
   
   # Original grouping
-  original_grouping_names = formula_composition |> formula_to_random_effect_formulae() |> pull(grouping)
+  original_grouping_names = original_formula_composition |> formula_to_random_effect_formulae() |> pull(grouping)
   
   # Random intercept
   random_effect_elements = parse_formula_random_effect(formula_composition)
@@ -468,6 +469,7 @@ replicate_data = function(.data,
     .cell_group = !!.cell_group,
     .count = !!.count,
     formula_composition = formula_composition,
+    original_formula_composition = .data |> attr("formula_composition"),
     formula_variability = formula_variability,
     new_data = new_data,
     original_count_data =


### PR DESCRIPTION
… for grouping names

- Modified the `prepare_replicate_data` function to accept `original_formula_composition` as a parameter.
- Updated the calculation of `original_grouping_names` to utilize `original_formula_composition` instead of `formula_composition`.
- Enhanced the `replicate_data` function to pass the original formula composition from the data attributes.