### PR TITLE
Enhance sccomp_predict and summary_to_tibble functions to support rob…

### DIFF
--- a/man/sccomp_predict.Rd
+++ b/man/sccomp_predict.Rd
@@ -10,7 +10,8 @@ sccomp_predict(
   new_data = NULL,
   number_of_draws = 500,
   mcmc_seed = sample_seed(),
-  summary_instead_of_draws = TRUE
+  summary_instead_of_draws = TRUE,
+  robust = FALSE
 )
 }
 \arguments{
@@ -25,13 +26,15 @@ sccomp_predict(
 \item{mcmc_seed}{An integer. Used for Markov-chain Monte Carlo reproducibility. By default a random number is sampled from 1 to 999999. This itself can be controlled by set.seed()}
 
 \item{summary_instead_of_draws}{Return the summary values (i.e. mean and quantiles) of the predicted proportions, or return single draws. Single draws can be helful to better analyse the uncertainty of the prediction.}
+
+\item{robust}{A logical. If TRUE, use robust statistics (median and median absolute deviation) instead of classical statistics (mean and standard deviation) for the summary calculations.}
 }
 \value{
 A tibble (\code{tbl}) with the following columns:
 \itemize{
 \item \strong{cell_group} - A character column representing the cell group being tested.
 \item \strong{sample} - A factor column representing the sample name for which the predictions are made.
-\item \strong{proportion_mean} - A numeric column representing the predicted mean proportions from the model.
+\item \strong{proportion_mean} - A numeric column representing the predicted mean (or median when robust=TRUE) proportions from the model.
 \item \strong{proportion_lower} - A numeric column representing the lower bound (2.5\%) of the 95\% credible interval for the predicted proportions.
 \item \strong{proportion_upper} - A numeric column representing the upper bound (97.5\%) of the 95\% credible interval for the predicted proportions.
 }

--- a/tests/testthat/test-sccomp_.R
+++ b/tests/testthat/test-sccomp_.R
@@ -184,6 +184,22 @@ test_that("Predict data",{
       number_of_draws = 1
     )
   
+  # Test robust parameter
+  prediction_robust = 
+    my_estimate |>
+    sccomp_predict(
+      formula_composition = ~ type,
+      new_data = new_data_tibble,
+      robust = TRUE,
+      number_of_draws = 1
+    )
+  
+  # Test that robust prediction works and returns expected columns
+  expect_true("proportion_mean" %in% colnames(prediction_robust))
+  expect_true("proportion_lower" %in% colnames(prediction_robust))
+  expect_true("proportion_upper" %in% colnames(prediction_robust))
+  expect_equal(nrow(prediction_robust), 60)
+  
 })
 
 test_that("outliers",{


### PR DESCRIPTION
…ust statistics

- Added a new parameter `robust` to `sccomp_predict` and `summary_to_tibble` functions to allow users to choose between classical and robust statistics for summary calculations.
- Updated documentation to reflect the new `robust` parameter and its implications on the output.
- Modified the prediction logic to return median and median absolute deviation when `robust` is set to TRUE.
- Added tests to ensure robust predictions return expected columns and values.