### PR TITLE
Add pkgdown workflow for R package deployment

### DIFF
--- a/.github/workflows/workflow_with_cmdstanr.yml
+++ b/.github/workflows/workflow_with_cmdstanr.yml
@@ -74,3 +74,64 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+
+  pkgdown:
+    runs-on: ubuntu-latest
+    needs: workflow_with_cmdstanr
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+    permissions:
+      contents: write
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: 'release'
+          use-public-rspm: true
+
+      - name: Install R dependencies
+        shell: Rscript {0}
+        run: |
+          install.packages("SeuratObject")
+          if (!requireNamespace("BiocManager", quietly = TRUE)) install.packages("BiocManager")
+          BiocManager::install()
+          if (!requireNamespace("devtools", quietly = TRUE)) install.packages("devtools")
+          devtools::install_deps(dependencies = TRUE)
+
+      - name: Install CmdStan
+        shell: Rscript {0}
+        run: |
+          install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
+          cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+          cmdstanr::install_cmdstan(cores = 2)
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          extra-packages: |
+            any::pkgdown
+            any::knitr
+            any::rmarkdown
+            any::ggplot2
+            any::tibble
+            any::dplyr
+            any::prettydoc
+
+      - name: Deploy package
+        shell: Rscript {0}
+        run: |
+          pkgdown::build_site()
+        env:
+          GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs


### PR DESCRIPTION
- Introduced a new job in the GitHub Actions workflow to build and deploy the pkgdown site.
- Configured steps for R environment setup, installation of dependencies, and CmdStan.
- Added deployment steps to upload the generated site artifacts to GitHub Pages.